### PR TITLE
Propagate tags from instance template to instance metadata.

### DIFF
--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeProvider.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeProvider.java
@@ -279,14 +279,20 @@ public class GoogleComputeProvider
           "/zones/" + zone +
           "/machineTypes/" + machineTypeName;
 
-      // Compose the instance metadata containing the SSH public key and user name.
+      // Compose the instance metadata containing the SSH public key, user name and tags.
       String sshUserName = template.getConfigurationValue(SSH_USERNAME,
           templateLocalizationContext);
       String sshPublicKey = template.getConfigurationValue(SSH_OPENSSH_PUBLIC_KEY,
           templateLocalizationContext);
       String sshKeysValue = sshUserName + ":" + sshPublicKey;
-      Metadata.Items metadataItems = new Metadata.Items().setKey("sshKeys").setValue(sshKeysValue);
-      Metadata metadata = new Metadata().setItems(Arrays.asList(new Metadata.Items[]{metadataItems}));
+      List<Metadata.Items> metadataItemsList = new ArrayList<Metadata.Items>();
+      metadataItemsList.add(new Metadata.Items().setKey("sshKeys").setValue(sshKeysValue));
+
+      for (Map.Entry<String, String> tag : template.getTags().entrySet()) {
+        metadataItemsList.add(new Metadata.Items().setKey(tag.getKey()).setValue(tag.getValue()));
+      }
+
+      Metadata metadata = new Metadata().setItems(metadataItemsList);
 
       // Compose the instance.
       Instance instance = new Instance();

--- a/tests/src/test/java/com/cloudera/director/google/GoogleTest.java
+++ b/tests/src/test/java/com/cloudera/director/google/GoogleTest.java
@@ -180,9 +180,12 @@ public class GoogleTest {
     templateConfig.put(SSH_OPENSSH_PUBLIC_KEY.unwrap().getConfigKey(), SSH_PUBLIC_KEY);
     templateConfig.put(SSH_USERNAME.unwrap().getConfigKey(), USER_NAME);
 
+    Map<String, String> tags = new HashMap<String, String>();
+    tags.put("test-tag-1", "some-value-1");
+    tags.put("test-tag-2", "some-value-2");
+
     ComputeInstanceTemplate template =
-        compute.createResourceTemplate("template-1", new SimpleConfiguration(templateConfig),
-            new HashMap<String, String>());
+        compute.createResourceTemplate("template-1", new SimpleConfiguration(templateConfig), tags);
 
     assertNotNull(template);
 


### PR DESCRIPTION
Closes #28 .
