### PR TITLE
Switch from jar metadata to Java ServiceLoader

### DIFF
--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -72,19 +72,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Cloudera-Director-SPI-Version>v1</Cloudera-Director-SPI-Version>
-                            <Cloudera-Director-Launcher-Class>${launcher-class}</Cloudera-Director-Launcher-Class>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>

--- a/provider/src/main/resources/META-INF/services/com.cloudera.director.spi.v1.provider.Launcher
+++ b/provider/src/main/resources/META-INF/services/com.cloudera.director.spi.v1.provider.Launcher
@@ -1,0 +1,1 @@
+com.cloudera.director.google.GoogleLauncher


### PR DESCRIPTION
We decided to move away from jar metadata to using the Java ServiceLoader
as a more standard mechanism for discovering classes implementing a given
interface.
