### PR TITLE
Google fixup user agent

### DIFF
--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -24,6 +24,8 @@
     <artifactId>google-provider</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
+    <name>Cloudera-Director-Google-Plugin</name>
+
     <properties>
         <launcher-class>com.cloudera.director.google.GoogleLauncher</launcher-class>
         <director-spi-v1.version>1.0.0-SNAPSHOT</director-spi-v1.version>
@@ -69,6 +71,13 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/provider/src/main/java/com/cloudera/director/google/GoogleCredentialsProvider.java
+++ b/provider/src/main/java/com/cloudera/director/google/GoogleCredentialsProvider.java
@@ -27,6 +27,7 @@ import com.cloudera.director.spi.v1.provider.CredentialsProvider;
 import com.cloudera.director.spi.v1.provider.CredentialsProviderMetadata;
 import com.cloudera.director.spi.v1.provider.util.SimpleCredentialsProviderMetadata;
 import com.cloudera.director.spi.v1.util.ConfigurationPropertiesUtil;
+import com.typesafe.config.Config;
 
 import java.util.List;
 
@@ -42,6 +43,12 @@ public class GoogleCredentialsProvider implements CredentialsProvider<GoogleCred
   public static CredentialsProviderMetadata METADATA =
       new SimpleCredentialsProviderMetadata(CONFIGURATION_PROPERTIES);
 
+  private Config applicationProperties;
+
+  public GoogleCredentialsProvider(Config applicationProperties) {
+    this.applicationProperties = applicationProperties;
+  }
+
   @Override
   public CredentialsProviderMetadata getMetadata() {
     return METADATA;
@@ -51,6 +58,7 @@ public class GoogleCredentialsProvider implements CredentialsProvider<GoogleCred
   public GoogleCredentials createCredentials(Configured configuration,
       LocalizationContext localizationContext) {
     return new GoogleCredentials(
+        applicationProperties,
         configuration.getConfigurationValue(PROJECTID, localizationContext),
         configuration.getConfigurationValue(JSONKEY, localizationContext)
     );

--- a/provider/src/main/java/com/cloudera/director/google/GoogleLauncher.java
+++ b/provider/src/main/java/com/cloudera/director/google/GoogleLauncher.java
@@ -37,8 +37,10 @@ import java.util.Locale;
 public class GoogleLauncher extends AbstractLauncher {
 
   private static final String GOOGLE_CONFIG_FILENAME = "/com/cloudera/director/google/google.conf";
+  private static final String APPLICATION_PROPERTIES_FILENAME = "/com/cloudera/director/google/application.properties";
 
   private Config googleConfig = null;
+  private Config applicationProperties = null;
 
   public GoogleLauncher() {
     super(Collections.singletonList(GoogleCloudProvider.METADATA), null);
@@ -53,6 +55,7 @@ public class GoogleLauncher extends AbstractLauncher {
   public void initialize(File configurationDirectory) {
     try {
       googleConfig = parseConfigFromClasspath(GOOGLE_CONFIG_FILENAME);
+      applicationProperties = parseConfigFromClasspath(APPLICATION_PROPERTIES_FILENAME);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -114,7 +117,7 @@ public class GoogleLauncher extends AbstractLauncher {
     // At this point the configuration object will already contain
     // the required data for authentication.
 
-    CredentialsProvider<GoogleCredentials> provider = new GoogleCredentialsProvider();
+    CredentialsProvider<GoogleCredentials> provider = new GoogleCredentialsProvider(applicationProperties);
     GoogleCredentials credentials = provider.createCredentials(configuration, localizationContext);
     Compute compute = credentials.getCompute();
 

--- a/provider/src/main/java/com/cloudera/director/google/internal/GoogleCredentials.java
+++ b/provider/src/main/java/com/cloudera/director/google/internal/GoogleCredentials.java
@@ -23,25 +23,26 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.ComputeScopes;
+import com.typesafe.config.Config;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 
 public class GoogleCredentials {
 
-  private final static String APPLICATION_NAME = "Cloudera";
-
+  private final Config applicationProperties;
   private final String projectId;
   private final String jsonKey;
   private final Compute compute;
 
-  public GoogleCredentials(String projectId, String jsonKey) {
+  public GoogleCredentials(Config applicationProperties, String projectId, String jsonKey) {
+    this.applicationProperties = applicationProperties;
     this.projectId = projectId;
     this.jsonKey = jsonKey;
-    this.compute = buildCompute(jsonKey);
+    this.compute = buildCompute();
   }
 
-  private static Compute buildCompute(String jsonKey) {
+  private Compute buildCompute() {
     try {
       JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
       HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
@@ -53,7 +54,8 @@ public class GoogleCredentials {
       return new Compute.Builder(httpTransport,
           JSON_FACTORY,
           null)
-          .setApplicationName(APPLICATION_NAME)
+          .setApplicationName(applicationProperties.getString("application.name") + "/" +
+              applicationProperties.getString("application.version"))
           .setHttpRequestInitializer(credential)
           .build();
 

--- a/provider/src/main/resources/com/cloudera/director/google/application.properties
+++ b/provider/src/main/resources/com/cloudera/director/google/application.properties
@@ -1,0 +1,2 @@
+application.name=${pom.name}
+application.version=${pom.version}


### PR DESCRIPTION
Will need to be rebased after #38 is merged.
Closes #35.
Via the GCP logs, user agent string gets sent as:
`user_agent: "Cloudera-Director-Google-Plugin/1.0.0-SNAPSHOT Google-API-Java-Client Google-HTTP-Java-Client/1.20.0 (gzip),gzip(gfe)"`
