### PR TITLE
Fetch Cloudera Director SPI from repository.cloudera.com

### DIFF
--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -83,6 +83,14 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>cloudera.repo</id>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+            <name>Cloudera Repository</name>
+        </repository>
+    </repositories>
+
     <build>
         <resources>
             <resource>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -104,6 +104,14 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>cloudera.repo</id>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+            <name>Cloudera Repository</name>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Now that the SPI is public and it was published on repository.cloudera.com
we can remove the requirement of having to build it locally in order to be
able to build the plugin itself.