### PR TITLE
Add names to compute instance display properties.

### DIFF
--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstance.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstance.java
@@ -65,6 +65,7 @@ public class GoogleComputeInstance
 
     IMAGE_ID(new SimpleDisplayPropertyBuilder()
         .displayKey("imageId")
+        .name("Image ID")
         .defaultDescription("The ID of the image used to launch the instance.")
         .sensitive(false)
         .build()) {
@@ -79,6 +80,7 @@ public class GoogleComputeInstance
      */
     INSTANCE_ID(new SimpleDisplayPropertyBuilder()
         .displayKey("instanceId")
+        .name("Instance ID")
         .defaultDescription("The ID of the instance.")
         .sensitive(false)
         .build()) {
@@ -93,6 +95,7 @@ public class GoogleComputeInstance
      */
     INSTANCE_TYPE(new SimpleDisplayPropertyBuilder()
         .displayKey("instanceType")
+        .name("Machine type")
         .defaultDescription("The instance type.")
         .sensitive(false)
         .build()) {
@@ -107,6 +110,7 @@ public class GoogleComputeInstance
      */
     LAUNCH_TIME(new SimpleDisplayPropertyBuilder()
         .displayKey("launchTime")
+        .name("Launch time")
         .defaultDescription("The time the instance was launched.")
         .sensitive(false)
         .build()) {
@@ -141,6 +145,7 @@ public class GoogleComputeInstance
      */
     PRIVATE_IP_ADDRESS(new SimpleDisplayPropertyBuilder()
         .displayKey("privateIpAddress")
+        .name("Internal IP")
         .defaultDescription("The private IP address assigned to the instance.")
         .sensitive(false)
         .build()) {
@@ -161,6 +166,7 @@ public class GoogleComputeInstance
      */
     PUBLIC_IP_ADDRESS(new SimpleDisplayPropertyBuilder()
         .displayKey("publicIpAddress")
+        .name("External IP")
         .defaultDescription("The public IP address assigned to the instance.")
         .sensitive(false)
         .build()) {


### PR DESCRIPTION
Added label names for compute instance display properties to be used in the Director UI. 
<img width="1033" alt="gcp_compute_instance_display_properties" src="https://cloud.githubusercontent.com/assets/1149703/11517810/aa6a0024-9851-11e5-8c2e-767e0776e9ee.png">
