### PR TITLE
Add support to tests for JSON_KEY_INLINE as alternative to JSON_KEY_P…

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,6 +29,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <director-spi-v1.version>1.0.0</director-spi-v1.version>
+        <commons-codec.version>1.10</commons-codec.version>
         <commons-logging.version>1.1.1</commons-logging.version>
         <slf4j.version>1.7.10</slf4j.version>
         <logback.version>1.1.2</logback.version>
@@ -45,6 +46,12 @@
             <groupId>com.cloudera.director</groupId>
             <artifactId>director-spi-v1</artifactId>
             <version>${director-spi-v1.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
         </dependency>
 
         <dependency>

--- a/tests/src/test/java/com/cloudera/director/google/TestFixture.java
+++ b/tests/src/test/java/com/cloudera/director/google/TestFixture.java
@@ -16,6 +16,8 @@
 
 package com.cloudera.director.google;
 
+import org.apache.commons.codec.binary.Base64;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 
@@ -39,6 +41,17 @@ public final class TestFixture {
   public static TestFixture newTestFixture(boolean sshPublicKeyAndUserNameAreRequired) throws IOException {
     String projectId = TestUtils.readRequiredSystemProperty("GCP_PROJECT_ID");
     String jsonKey = TestUtils.readFileIfSpecified(System.getProperty("JSON_KEY_PATH", ""));
+
+    // If the path to a json key file was not provided, check if the key was passed explicitly.
+    if (jsonKey == null) {
+      String jsonKeyInline = System.getProperty("JSON_KEY_INLINE", "");
+
+      if (!jsonKeyInline.isEmpty()) {
+        // If so, we must base64-decode it.
+        jsonKey = new String(Base64.decodeBase64(jsonKeyInline));
+      }
+    }
+
     String sshPublicKey = null;
     String userName = null;
 


### PR DESCRIPTION
…ATH.
If we are going to use encrypted environment variables, we'll need to be able to pass the json key explicitly instead of requiring a file path.