### PR TITLE
Update centos6 image alias to keep in sync with rhel6 image alias

### DIFF
--- a/provider/src/main/resources/com/cloudera/director/google/google.conf
+++ b/provider/src/main/resources/com/cloudera/director/google/google.conf
@@ -1,7 +1,7 @@
 google {
   compute {
     imageAliases {
-      centos6 = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20151104",
+      centos6 = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160119",
       rhel6 = "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20160119"
     }
   }

--- a/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
+++ b/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
@@ -122,7 +122,7 @@ public class GoogleLauncherTest {
     launcher.initialize(configDir, null);
 
     // Verify that base config is reflected.
-    assertEquals("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20151104",
+    assertEquals("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160119",
         launcher.googleConfig.getString(Configurations.IMAGE_ALIASES_SECTION + "centos6"));
 
     // Verify that overridden config is reflected.


### PR DESCRIPTION
Updated centos image per @mbrukman 's suggestion.