### PR TITLE
Exclude javax.annotation source files from JAR

### DIFF
--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -144,6 +144,12 @@
                                 <exclude>META-INF/*.RSA</exclude>
                             </excludes>
                         </filter>
+                        <filter>
+                            <artifact>com.google.code.findbugs:jsr305</artifact>
+                            <excludes>
+                                <exclude>**/*.java</exclude>
+                            </excludes>
+                        </filter>
                     </filters>
                 </configuration>
                 <executions>


### PR DESCRIPTION
The configuration for the Maven shade plugin now filters out source
files for JSR 305 annotations th at are carried over from the Findbugs
JSR 305 dependency.