### PR TITLE
Make polling time for pending GCP compute ops configurable

### DIFF
--- a/provider/src/main/java/com/cloudera/director/google/Configurations.java
+++ b/provider/src/main/java/com/cloudera/director/google/Configurations.java
@@ -55,4 +55,14 @@ public class Configurations {
    * The HOCON path prefix for Cloud SQL regions configuration.
    */
   public static final String CLOUD_SQL_REGIONS_ALIASES_SECTION = "google.cloudSQL.regions.toComputeRegion.";
+
+  /**
+   * The HOCON key for the polling timeout, in seconds, for pending compute operations.
+   */
+  public static final String COMPUTE_POLLING_TIMEOUT_KEY = "google.compute.pollingTimeoutSeconds";
+
+  /**
+   * The HOCON key for the maximum polling interval, in seconds, for pending compute operations.
+   */
+  public static final String COMPUTE_MAX_POLLING_INTERVAL_KEY = "google.compute.maxPollingIntervalSeconds";
 }

--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeProvider.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeProvider.java
@@ -360,7 +360,8 @@ public class GoogleComputeProvider
       instance.setTags(tags);
 
       // Wait for operations to reach DONE state before provisioning the instance.
-      List<Operation> successfulOperations = pollPendingOperations(projectId, diskCreationOperations, DONE_STATE, compute, accumulator);
+      List<Operation> successfulOperations = pollPendingOperations(projectId, diskCreationOperations, DONE_STATE,
+          compute, googleConfig, accumulator);
 
       // We need to ensure that any data disks that were successfully created are deleted in case of teardown.
       for (Operation successfulOperation : successfulOperations) {
@@ -388,7 +389,7 @@ public class GoogleComputeProvider
     // Wait for operations to reach DONE state before returning.
     // This is the status of the Operations we're referring to, not of the Instances.
     List<Operation> successfulOperations = pollPendingOperations(projectId, vmCreationOperations, DONE_STATE,
-        compute, accumulator);
+        compute, googleConfig, accumulator);
 
     int successfulOperationCount = successfulOperations.size();
 
@@ -515,7 +516,7 @@ public class GoogleComputeProvider
     }
 
     List<Operation> successfulTearDownOperations = pollPendingOperations(projectId, tearDownOperations, DONE_STATE,
-        compute, accumulator);
+        compute, googleConfig, accumulator);
     int tearDownOperationCount = tearDownOperations.size();
     int successfulTearDownOperationCount = successfulTearDownOperations.size();
 
@@ -687,7 +688,8 @@ public class GoogleComputeProvider
     // Wait for operations to reach RUNNING or DONE state before returning.
     // Quotas are verified prior to reaching the RUNNING state.
     // This is the status of the Operations we're referring to, not of the Instances.
-    pollPendingOperations(projectId, vmDeletionOperations, RUNNING_OR_DONE_STATES, compute, accumulator);
+    pollPendingOperations(projectId, vmDeletionOperations, RUNNING_OR_DONE_STATES, compute, googleConfig,
+        accumulator);
 
     if (accumulator.hasError()) {
       PluginExceptionDetails pluginExceptionDetails = new PluginExceptionDetails(accumulator.getConditionsByKey());
@@ -728,14 +730,15 @@ public class GoogleComputeProvider
   // All arguments are required and must be non-null.
   // Returns the number of operations that reached one of the acceptable states within the timeout period.
   private static List<Operation> pollPendingOperations(String projectId, List<Operation> origPendingOperations,
-      List<String> acceptableStates, Compute compute, PluginExceptionConditionAccumulator accumulator)
+      List<String> acceptableStates, Compute compute, Config googleConfig,
+      PluginExceptionConditionAccumulator accumulator)
           throws InterruptedException {
     // Clone the list so we can prune it without modifying the original.
     List<Operation> pendingOperations = new ArrayList<Operation>(origPendingOperations);
 
     int totalTimePollingSeconds = 0;
-    int pollingTimeoutSeconds = 180;
-    int maxPollingIntervalSeconds = 8;
+    int pollingTimeoutSeconds = googleConfig.getInt(Configurations.COMPUTE_POLLING_TIMEOUT_KEY);
+    int maxPollingIntervalSeconds = googleConfig.getInt(Configurations.COMPUTE_MAX_POLLING_INTERVAL_KEY);
     boolean timeoutExceeded = false;
 
     // Fibonacci backoff in seconds, up to maxPollingIntervalSeconds interval.

--- a/provider/src/main/resources/com/cloudera/director/google/google.conf
+++ b/provider/src/main/resources/com/cloudera/director/google/google.conf
@@ -4,6 +4,8 @@ google {
       centos6 = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160526",
       rhel6 = "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20160511"
     }
+    maxPollingIntervalSeconds = 8
+    pollingTimeoutSeconds = 180
   }
   cloudSQL {
     regions {

--- a/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
+++ b/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
@@ -115,6 +115,7 @@ public class GoogleLauncherTest {
     printWriter.println("      rhel6 = \"https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20150430\",");
     printWriter.println("      ubuntu = \"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20150128\"");
     printWriter.println("    }");
+    printWriter.println("    pollingTimeoutSeconds = 300");
     printWriter.println("  }");
     printWriter.println("}");
     printWriter.close();
@@ -124,10 +125,12 @@ public class GoogleLauncherTest {
     // Verify that base config is reflected.
     assertEquals("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160526",
         launcher.googleConfig.getString(Configurations.IMAGE_ALIASES_SECTION + "centos6"));
+    assertEquals(8, launcher.googleConfig.getInt(Configurations.COMPUTE_MAX_POLLING_INTERVAL_KEY));
 
     // Verify that overridden config is reflected.
     assertEquals("https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20150430",
         launcher.googleConfig.getString(Configurations.IMAGE_ALIASES_SECTION + "rhel6"));
+    assertEquals(300, launcher.googleConfig.getInt(Configurations.COMPUTE_POLLING_TIMEOUT_KEY));
 
     // Verify that new config is reflected.
     assertEquals("https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20150128",

--- a/tests/src/test/java/com/cloudera/director/google/TestUtils.java
+++ b/tests/src/test/java/com/cloudera/director/google/TestUtils.java
@@ -76,6 +76,8 @@ public class TestUtils {
         Configurations.CLOUD_SQL_REGIONS_ALIASES_SECTION + "europe-west1", "europe-west1");
     googleConfig.put(
         Configurations.CLOUD_SQL_REGIONS_ALIASES_SECTION + "asia-east1", "asia-east1");
+    googleConfig.put(Configurations.COMPUTE_POLLING_TIMEOUT_KEY, "180");
+    googleConfig.put(Configurations.COMPUTE_MAX_POLLING_INTERVAL_KEY, "8");
 
     return ConfigFactory.parseMap(googleConfig);
   }


### PR DESCRIPTION
The formerly fixed timeout of three minutes and maximum interval of
eight seconds which the Google plugin uses for polling the completion of
pending compute operations are now configurable in the plugin's
`google.conf` file. The default file preserves the original hardcoded
values.