### PR TITLE
Make polling time for pending GCP compute ops configurable

### DIFF
--- a/provider/src/main/java/com/cloudera/director/google/Configurations.java
+++ b/provider/src/main/java/com/cloudera/director/google/Configurations.java
@@ -50,4 +50,14 @@ public class Configurations {
    * The HOCON path prefix for image aliases configuration.
    */
   public static final String IMAGE_ALIASES_SECTION = "google.compute.imageAliases.";
+
+  /**
+   * The HOCON key for the polling timeout, in seconds, for pending compute operations.
+   */
+  public static final String COMPUTE_POLLING_TIMEOUT_KEY = "google.compute.pollingTimeoutSeconds";
+
+  /**
+   * The HOCON key for the maximum polling interval, in seconds, for pending compute operations.
+   */
+  public static final String COMPUTE_MAX_POLLING_INTERVAL_KEY = "google.compute.maxPollingIntervalSeconds";
 }

--- a/provider/src/main/resources/com/cloudera/director/google/google.conf
+++ b/provider/src/main/resources/com/cloudera/director/google/google.conf
@@ -4,5 +4,7 @@ google {
       centos6 = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160526",
       rhel6 = "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20160511"
     }
+    maxPollingIntervalSeconds = 8
+    pollingTimeoutSeconds = 180
   }
 }

--- a/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
+++ b/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
@@ -29,7 +29,6 @@ import com.cloudera.director.spi.v1.provider.CloudProviderMetadata;
 import com.cloudera.director.spi.v1.provider.Launcher;
 
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -57,20 +56,13 @@ import java.util.Map;
  */
 public class GoogleLauncherTest {
 
-  private static TestFixture testFixture;
-
-  @BeforeClass
-  public static void beforeClass() throws IOException {
-    Assume.assumeFalse(System.getProperty("GCP_PROJECT_ID", "").isEmpty());
-
-    testFixture = TestFixture.newTestFixture(false);
-  }
-
   @Rule
   public TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
   @Test
   public void testLauncher() throws IOException {
+    Assume.assumeFalse(System.getProperty("GCP_PROJECT_ID", "").isEmpty());
+    TestFixture testFixture = TestFixture.newTestFixture(false);
 
     Launcher launcher = new GoogleLauncher();
     launcher.initialize(TEMPORARY_FOLDER.getRoot(), null);
@@ -122,6 +114,7 @@ public class GoogleLauncherTest {
     printWriter.println("      rhel6 = \"https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20150430\",");
     printWriter.println("      ubuntu = \"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20150128\"");
     printWriter.println("    }");
+    printWriter.println("    pollingTimeoutSeconds = 300");
     printWriter.println("  }");
     printWriter.println("}");
     printWriter.close();
@@ -131,10 +124,12 @@ public class GoogleLauncherTest {
     // Verify that base config is reflected.
     assertEquals("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160526",
         launcher.googleConfig.getString(Configurations.IMAGE_ALIASES_SECTION + "centos6"));
+    assertEquals(8, launcher.googleConfig.getInt(Configurations.COMPUTE_MAX_POLLING_INTERVAL_KEY));
 
     // Verify that overridden config is reflected.
     assertEquals("https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20150430",
         launcher.googleConfig.getString(Configurations.IMAGE_ALIASES_SECTION + "rhel6"));
+    assertEquals(300, launcher.googleConfig.getInt(Configurations.COMPUTE_POLLING_TIMEOUT_KEY));
 
     // Verify that new config is reflected.
     assertEquals("https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20150128",

--- a/tests/src/test/java/com/cloudera/director/google/TestUtils.java
+++ b/tests/src/test/java/com/cloudera/director/google/TestUtils.java
@@ -69,6 +69,8 @@ public class TestUtils {
     googleConfig.put(
         Configurations.IMAGE_ALIASES_SECTION + "rhel6",
         buildImageUrl("rhel-cloud", "rhel-6-v20150526"));
+    googleConfig.put(Configurations.COMPUTE_POLLING_TIMEOUT_KEY, "180");
+    googleConfig.put(Configurations.COMPUTE_MAX_POLLING_INTERVAL_KEY, "8");
 
     return ConfigFactory.parseMap(googleConfig);
   }


### PR DESCRIPTION
The formerly fixed timeout of three minutes and maximum interval of
eight seconds which the Google plugin uses for polling the completion of
pending compute operations are now configurable in the plugin's
google.conf file. The default file preserves the original hardcoded
values.