### PR TITLE
Remove OpenJDK 6 as a build configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-################################################################################
 
 language: java
 
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - openjdk6
 
 script:
   - mvn clean install
-

--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -47,7 +47,7 @@
         <maven-shade-plugin.version>2.3</maven-shade-plugin.version>
         <shade-prefix>com.cloudera.director.google.shaded</shade-prefix>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
-        <java.version>1.6</java.version>
+        <java.version>1.7</java.version>
     </properties>
 
     <dependencies>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -45,7 +45,7 @@
         <mockito.version>1.10.19</mockito.version>
         <guava.version>15.0</guava.version>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
-        <java.version>1.6</java.version>
+        <java.version>1.7</java.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Director 2.0 release made JDK 7 a minimum requirement, per @andreisavu