### PR TITLE
Add etc/labels.conf from Director distribution

### DIFF
--- a/provider/etc/labels.conf
+++ b/provider/etc/labels.conf
@@ -1,0 +1,54 @@
+# Copyright (c) 2017 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+  google {
+    configurationProperties {
+    },
+    credentialsProperties {
+    },
+    "com.cloudera.director.google.compute.GoogleComputeProvider" {
+      configurationProperties {
+      },
+      templateProperties {
+      },
+      resourceProperties {
+        privateIpAddress : [
+          {
+            type : hostEndpoint,
+            variant : privateIp,
+            key : name
+          },
+          {
+            type : hostEndpoint,
+            variant : privateIp,
+            key : address
+          }
+        ],
+        publicIpAddress : [
+          {
+            type : hostEndpoint,
+            variant : publicIp,
+            key : name
+          },
+          {
+            type : hostEndpoint,
+            variant : publicIp,
+            key : address
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
The labels.conf file is used by Cloudera Director to populate its UI with items specific to the Google plugin. This file ships with each Director release, but it should be instead disseminated to the public with the rest of the plugin, so that new items can be easily added.