### PR TITLE
Update CentOS and RHEL image aliases to v20171025.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 language: java
+dist: trusty
+sudo: false
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk7
 
 script:
   - mvn clean install

--- a/provider/src/main/resources/com/cloudera/director/google/google.conf
+++ b/provider/src/main/resources/com/cloudera/director/google/google.conf
@@ -1,8 +1,8 @@
 google {
   compute {
     imageAliases {
-      centos6 = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160526",
-      rhel6 = "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20160511"
+      centos6 = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20171025",
+      rhel6 = "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20171025"
     }
     maxPollingIntervalSeconds = 8
     pollingTimeoutSeconds = 180

--- a/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
+++ b/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
@@ -123,7 +123,7 @@ public class GoogleLauncherTest {
     launcher.initialize(configDir, null);
 
     // Verify that base config is reflected.
-    assertEquals("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160526",
+    assertEquals("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20171025",
         launcher.googleConfig.getString(Configurations.IMAGE_ALIASES_SECTION + "centos6"));
     assertEquals(8, launcher.googleConfig.getInt(Configurations.COMPUTE_MAX_POLLING_INTERVAL_KEY));
 


### PR DESCRIPTION
Latest versions identified via:

    gcloud compute images list | egrep '^(centos|rhel)-6'

This is a short-term manual fix for issue #136, which should get a proper implementation.