### PR TITLE
Bump master branch to 2.1.0-SNAPSHOT, require Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ sudo: false
 
 jdk:
   - oraclejdk8
-  - openjdk7
+  - openjdk8
 
 script:
   - mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>com.cloudera.director</groupId>
     <artifactId>google</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -47,7 +47,7 @@
         <maven-shade-plugin.version>2.3</maven-shade-plugin.version>
         <shade-prefix>com.cloudera.director.google.shaded</shade-prefix>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
     </properties>
 
     <dependencies>

--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.cloudera.director</groupId>
         <artifactId>google</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.cloudera.director</groupId>
         <artifactId>google</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -45,7 +45,7 @@
         <mockito.version>1.10.19</mockito.version>
         <guava.version>15.0</guava.version>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
We're moving (finally) towards Java 8 as a minimum for Director development. To go along with that, these changes bump the master branch of the Google plugin to 2.1.0-SNAPSHOT and require Java 8 for plugin and test compilation. (No Java 8 language features are included yet.)