### PR TITLE
Update maven-shade-plugin version and image aliases

### DIFF
--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -42,7 +42,7 @@
         <typesafe-config.version>1.2.0</typesafe-config.version>
         <joda-time.version>2.8</joda-time.version>
         <junit.version>4.12</junit.version>
-        <maven-shade-plugin.version>2.3</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
         <shade-prefix>com.cloudera.director.google.shaded</shade-prefix>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <java.version>1.8</java.version>

--- a/provider/src/main/resources/com/cloudera/director/google/google.conf
+++ b/provider/src/main/resources/com/cloudera/director/google/google.conf
@@ -1,8 +1,8 @@
 google {
   compute {
     imageAliases {
-      centos6 = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160526",
-      rhel6 = "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20160511"
+      centos6 = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20180611",
+      rhel6 = "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-6-v20180611"
     }
     maxPollingIntervalSeconds = 8
     pollingTimeoutSeconds = 180

--- a/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
+++ b/tests/src/test/java/com/cloudera/director/google/GoogleLauncherTest.java
@@ -122,7 +122,7 @@ public class GoogleLauncherTest {
     launcher.initialize(configDir, null);
 
     // Verify that base config is reflected.
-    assertEquals("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20160526",
+    assertEquals("https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20180611",
         launcher.googleConfig.getString(Configurations.IMAGE_ALIASES_SECTION + "centos6"));
     assertEquals(8, launcher.googleConfig.getInt(Configurations.COMPUTE_MAX_POLLING_INTERVAL_KEY));
 


### PR DESCRIPTION
Cherry-pick maven-shade-plugin version and image aliases commits back to v2.0.x branch