### PR TITLE
Add option for subnetwork in templates.

### DIFF
--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationProperty.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationProperty.java
@@ -63,6 +63,15 @@ public enum GoogleComputeInstanceTemplateConfigurationProperty implements Config
       .required(false)
       .build()),
 
+  SUBNETWORK_NAME(new SimpleConfigurationPropertyBuilder()
+      .configKey("subnetworkName")
+      .name("Subnetwork Name")
+      .defaultDescription("The subnetwork identifier.<br />" +
+              "<a target='_blank' href='https://cloud.google.com/compute/docs/networking#networks'>More Information</a>")
+      .defaultValue(null)
+      .required(false)
+      .build()),
+
   ZONE(new SimpleConfigurationPropertyBuilder()
       .configKey("zone")
       .name("Zone")

--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeProvider.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeProvider.java
@@ -24,6 +24,7 @@ import static com.cloudera.director.google.compute.GoogleComputeInstanceTemplate
 import static com.cloudera.director.google.compute.GoogleComputeInstanceTemplateConfigurationProperty.IMAGE;
 import static com.cloudera.director.google.compute.GoogleComputeInstanceTemplateConfigurationProperty.LOCAL_SSD_INTERFACE_TYPE;
 import static com.cloudera.director.google.compute.GoogleComputeInstanceTemplateConfigurationProperty.NETWORK_NAME;
+import static com.cloudera.director.google.compute.GoogleComputeInstanceTemplateConfigurationProperty.SUBNETWORK_NAME;
 import static com.cloudera.director.google.compute.GoogleComputeInstanceTemplateConfigurationProperty.TYPE;
 import static com.cloudera.director.google.compute.GoogleComputeInstanceTemplateConfigurationProperty.USE_PREEMPTIBLE_INSTANCES;
 import static com.cloudera.director.google.compute.GoogleComputeInstanceTemplateConfigurationProperty.ZONE;
@@ -296,6 +297,7 @@ public class GoogleComputeProvider
 
       // Compose the network url.
       String networkName = template.getConfigurationValue(NETWORK_NAME, templateLocalizationContext);
+      String subnetName = template.getConfigurationValue(SUBNETWORK_NAME, templateLocalizationContext);
       String networkUrl = ComputeUrls.buildNetworkUrl(projectId, networkName);
 
       // Compose the network interface.
@@ -306,6 +308,12 @@ public class GoogleComputeProvider
       accessConfig.setType(accessConfigType);
       NetworkInterface networkInterface = new NetworkInterface();
       networkInterface.setNetwork(networkUrl);
+
+      if (subnetName != null) {
+        String region = template.getConfigurationValue(GoogleComputeProviderConfigurationProperty.REGION, templateLocalizationContext);
+        networkInterface.setSubnetwork(ComputeUrls.buildSubnetUrl(projectId, region, subnetName));
+      }
+
       networkInterface.setAccessConfigs(Arrays.asList(accessConfig));
 
       // Compose the machine type url.
@@ -373,14 +381,12 @@ public class GoogleComputeProvider
           Operation vmCreationOperation = compute.instances().insert(projectId, zone, instance).execute();
 
           vmCreationOperations.add(vmCreationOperation);
-        }
-        catch (GoogleJsonResponseException e) {
+        } catch (GoogleJsonResponseException e) {
           if (hasError(e, 409, "alreadyExists")) {
             preExistingVmCount++;
           }
           accumulator.addError(null, e.getMessage());
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
           accumulator.addError(null, e.getMessage());
         }
       }
@@ -731,8 +737,7 @@ public class GoogleComputeProvider
   // Returns the number of operations that reached one of the acceptable states within the timeout period.
   private static List<Operation> pollPendingOperations(String projectId, List<Operation> origPendingOperations,
       List<String> acceptableStates, Compute compute, Config googleConfig,
-      PluginExceptionConditionAccumulator accumulator)
-          throws InterruptedException {
+      PluginExceptionConditionAccumulator accumulator) throws InterruptedException {
     // Clone the list so we can prune it without modifying the original.
     List<Operation> pendingOperations = new ArrayList<Operation>(origPendingOperations);
 

--- a/provider/src/main/java/com/cloudera/director/google/compute/util/ComputeUrls.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/util/ComputeUrls.java
@@ -54,6 +54,10 @@ public class ComputeUrls {
     return buildGlobalUrl(projectId, "networks", networkName);
   }
 
+  public static String buildSubnetUrl(String projectId, String region, String subnetName){
+    return buildRegionalUrl(projectId, region, "subnetworks", subnetName);
+  }
+
   public static String buildZonalUrl(String projectId, String zone, String... resourcePathParts) {
     List<String> pathParts = Lists.newArrayList("zones", zone);
 


### PR DESCRIPTION
Simple first pass at a fix for https://github.com/cloudera/director-google-plugin/issues/118 so that templates can specify subnetworks.

I've verified that this works in production on Cloudera Director 2.8.0 with a custom subnetwork. 

Let me know if there's any other validation or testing that would be helpful.  Thanks!