### PR TITLE
Update NOTICE for CM API 6.0.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -16,7 +16,7 @@ Javassist 3.22.0
 Copyright (C) 1999-2018 by Shigeru Chiba, All rights reserved.
 Javassist 3.22.0 is licensed under the LGPL v2.1 or MPL 1.1 or Apache 2.0 licenses.  Cloudera, Inc. elects the Apache License, Version 2.0. A copy of the Apache License, Version 2.0 appears below.
 
-Cloudera Manager API 6.x.0
+Cloudera Manager API 6.0.0
 Copyright (C) 2012 – 2018 Cloudera, Inc.
 Licensed under the Apache License, Version 2.0. A copy of the Apache License, Version 2.0 appears below.
 


### PR DESCRIPTION
Director now uses CM API 6.0.0, instead of the previous shifting 6.x.0
version. The legal notice is updated accordingly.