### PR TITLE
Support user tags, a different project for the network (shared VPC), and removing external IPs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,4 +30,5 @@
         <module>provider</module>
         <module>tests</module>
     </modules>
+
 </project>

--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationProperty.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationProperty.java
@@ -63,6 +63,33 @@ public enum GoogleComputeInstanceTemplateConfigurationProperty implements Config
       .required(false)
       .build()),
 
+  NETWORK_PROJECT(new SimpleConfigurationPropertyBuilder()
+      .configKey("networkProject")
+      .name("Network Project")
+      .defaultDescription(
+          "The project the nework belongs to.<br />" +
+              "<a target='_blank' href='https://cloud.google.com/compute/docs/networking#networks'>More Information</a>")
+      .defaultValue(null)
+      .required(false)
+      .build()),
+
+  ASSIGN_EXTERNAL_IPS(new SimpleConfigurationPropertyBuilder()
+      .configKey("assignExternalIPs")
+      .name("Assign External IPs")
+      .defaultDescription("Assign external IP addresses to created instances.  Cloudera director will" +
+          "still require egress for package installation, but this can be provided with a Cloud NAT.")
+      .defaultValue("true")
+      .required(false)
+      .build()),
+
+  INSTANCE_TAGS(new SimpleConfigurationPropertyBuilder()
+      .configKey("instanceTags")
+      .name("Tags")
+      .defaultDescription("Instance tags")
+      .defaultValue(null)
+      .required(false)
+      .build()),
+
   SUBNETWORK_NAME(new SimpleConfigurationPropertyBuilder()
       .configKey("subnetworkName")
       .name("Subnetwork Name")


### PR DESCRIPTION
This may be niche, but was necessary for our setup.  We're spinning up VMs in a shared VPC (https://cloud.google.com/vpc/docs/shared-vpc), so we needed to specify a subnetwork from a different project from the created compute resources. 

We also want to tag provisioned instances with labels, for automatic application of firewall rules (mostly to expose UIs).

Disabling external IPs is good security practice.  This will initially break director spin-up since it installs centos packages, but is fixed by setting up Cloud NAT over the subnet to enable egress.

This is working for us, but I haven't aggressively tested it with different combinations of defaults/custom values.