### PR TITLE
Retrieve subnetwork region from provider and not the template.

### DIFF
--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeProvider.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeProvider.java
@@ -310,7 +310,8 @@ public class GoogleComputeProvider
       networkInterface.setNetwork(networkUrl);
 
       if (subnetName != null) {
-        String region = template.getConfigurationValue(GoogleComputeProviderConfigurationProperty.REGION, templateLocalizationContext);
+        String region = getConfigurationValue(GoogleComputeProviderConfigurationProperty.REGION,
+            providerLocalizationContext);
         networkInterface.setSubnetwork(ComputeUrls.buildSubnetUrl(projectId, region, subnetName));
       }
 


### PR DESCRIPTION
During allocation, the region is retrieved from the instance template
when trying to use subnetworks. The region is at the provider level,
however, and the region defaults to us-central1, which results in the
region inadvertently always being set to us-central1 during instance
allocation with subnetworks.