### PR TITLE
GCE allows 8 localssds per instance, not 4

### DIFF
--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationValidator.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationValidator.java
@@ -72,7 +72,7 @@ public class GoogleComputeInstanceTemplateConfigurationValidator implements Conf
   @VisibleForTesting
   static final int MIN_LOCAL_SSD_COUNT = 0;
   @VisibleForTesting
-  static final int MAX_LOCAL_SSD_COUNT = 4;
+  static final int MAX_LOCAL_SSD_COUNT = 8;
 
   @VisibleForTesting
   static final String ZONE_NOT_FOUND_MSG = "Zone '%s' not found for project '%s'.";

--- a/tests/src/test/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationValidatorTest.java
+++ b/tests/src/test/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationValidatorTest.java
@@ -121,7 +121,7 @@ public class GoogleComputeInstanceTemplateConfigurationValidatorTest {
   private static final String BOOT_DISK_SIZE_TOO_SMALL = "5";
   private static final String DATA_DISK_COUNT_VALUE = "2";
   private static final String DATA_DISK_COUNT_TOO_FEW = "-1";
-  private static final String DATA_DISK_COUNT_LOCAL_SSD_TOO_MANY = "5";
+  private static final String DATA_DISK_COUNT_LOCAL_SSD_TOO_MANY = "9";
   private static final String DATA_DISK_COUNT_MALFORMED = "three";
   private static final String DATA_DISK_TYPE_LOCAL_SSD = "LocalSSD";
   private static final String DATA_DISK_SIZE = "250";


### PR DESCRIPTION
Documented here: https://cloud.google.com/compute/docs/disks/local-ssd

Tested:
````
[bpodgursky@compute-worker-b9052d03-b69a-4042-baba-5be7d5dfa4d9 ~]$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda1       100G   20G   81G  20% /
devtmpfs        103G     0  103G   0% /dev
tmpfs           103G     0  103G   0% /dev/shm
tmpfs           103G  8.8M  103G   1% /run
tmpfs           103G     0  103G   0% /sys/fs/cgroup
tmpfs            21G     0   21G   0% /run/user/0
cm_processes    103G   96K  103G   1% /run/cloudera-scm-agent/process
tmpfs            21G     0   21G   0% /run/user/1001
/dev/sdh        369G   69M  369G   1% /data5
/dev/sdc        369G   69M  369G   1% /data3
/dev/sde        369G   69M  369G   1% /data6
/dev/sdi        369G   69M  369G   1% /data7
/dev/sdg        369G   69M  369G   1% /data4
/dev/sdd        369G   69M  369G   1% /data1
/dev/sdb        369G   69M  369G   1% /data2
/dev/sdf        369G   69M  369G   1% /data0
````