### PR TITLE
shared VPC support in the network validation

### DIFF
--- a/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationValidator.java
+++ b/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationValidator.java
@@ -474,6 +474,7 @@ public class GoogleComputeInstanceTemplateConfigurationValidator implements Conf
       LocalizationContext localizationContext) {
 
     String networkName = configuration.getConfigurationValue(NETWORK_NAME, localizationContext);
+    String networkProject = configuration.getConfigurationValue(NETWORK_PROJECT, localizationContext);
 
     if (networkName != null) {
       LOG.info(">> Querying network '{}'", networkName);
@@ -481,12 +482,16 @@ public class GoogleComputeInstanceTemplateConfigurationValidator implements Conf
       GoogleCredentials credentials = provider.getCredentials();
       Compute compute = credentials.getCompute();
       String projectId = credentials.getProjectId();
+      
+      if (networkProject == null) {
+        networkProject = projectId;
+      }
 
       try {
-        compute.networks().get(projectId, networkName).execute();
+        compute.networks().get(networkProject, networkName).execute();
       } catch (GoogleJsonResponseException e) {
         if (e.getStatusCode() == 404) {
-          addError(accumulator, NETWORK_NAME, localizationContext, null, NETWORK_NOT_FOUND_MSG, networkName, projectId);
+          addError(accumulator, NETWORK_NAME, localizationContext, null, NETWORK_NOT_FOUND_MSG, networkName, networkProject);
         } else {
           throw new TransientProviderException(e);
         }


### PR DESCRIPTION
Shared VPC support was added in https://github.com/cloudera/director-google-plugin/pull/161. This allowed for the possibility that the network resource lives in a separate project from the project where we want to create the compute instances. We need to add logic to this check to utilize the new `NETWORK_PROJECT` variable that we introduced so that we don't look in the wrong project for the network.

This logic is already present in the subnetwork check and was taken from there: https://github.com/cloudera/director-google-plugin/blob/91ae4386a2c54fa2c2de34f4e91ab98285876169/provider/src/main/java/com/cloudera/director/google/compute/GoogleComputeInstanceTemplateConfigurationValidator.java#L499-L532